### PR TITLE
fix protocol alone, add composite

### DIFF
--- a/filter/compile_test.go
+++ b/filter/compile_test.go
@@ -166,11 +166,11 @@ func TestExpressionNextPrimitive(t *testing.T) {
 func TestExpressionCompile(t *testing.T) {
 	for k, v := range testCasesExpressionFilterInstructions {
 		t.Run(k, func(t *testing.T) {
-			for _, tt := range v {
+			for i, tt := range v {
 				e := NewExpression(tt.expression)
 				f := e.Compile()
 				if !f.Equal(tt.filter) {
-					t.Errorf("%s: mismatched value\nactual   %#v\nexpected %#v", tt.expression, f, tt.filter)
+					t.Errorf("%d '%s': mismatched value\nactual   %#v\nexpected %#v", i, tt.expression, f, tt.filter)
 				}
 			}
 		})

--- a/filter/constants.go
+++ b/filter/constants.go
@@ -21,6 +21,7 @@ const (
 	ip4HeaderFlags             uint32 = 20
 	ip6SourceAddressStart      uint32 = 22
 	ip6DestinationAddressStart uint32 = 38
+	ip6ContinuationPacket      uint32 = 0x2c
 )
 
 type filterKind int

--- a/filter/expression.go
+++ b/filter/expression.go
@@ -164,9 +164,9 @@ func setPrimitiveDefaults(p, lastPrimitive *primitive) {
 		p.subProtocol = lastPrimitive.subProtocol
 	}
 	// special cases
-	if (p.subProtocol == filterSubProtocolUDP || p.subProtocol == filterSubProtocolTCP || p.subProtocol == filterSubProtocolIcmp) && p.protocol == filterProtocolUnset {
-		p.protocol = filterProtocolIP
-	}
+	//if (p.subProtocol == filterSubProtocolUDP || p.subProtocol == filterSubProtocolTCP || p.subProtocol == filterSubProtocolIcmp) && p.protocol == filterProtocolUnset {
+	//p.protocol = filterProtocolIP
+	//}
 
 	if p.kind == filterKindUnset && p.direction != filterDirectionUnset && (p.protocol == filterProtocolEther || p.protocol == filterProtocolIP || p.protocol == filterProtocolIP6 || p.protocol == filterProtocolArp || p.protocol == filterProtocolRarp) {
 		p.kind = filterKindHost
@@ -174,7 +174,7 @@ func setPrimitiveDefaults(p, lastPrimitive *primitive) {
 	if p.direction == filterDirectionUnset {
 		p.direction = filterDirectionSrcOrDst
 	}
-	if p.kind == filterKindUnset && p.protocol == filterProtocolUnset {
+	if p.kind == filterKindUnset && p.protocol == filterProtocolUnset && p.subProtocol == filterSubProtocolUnset {
 		p.kind = filterKindHost
 	}
 }


### PR DESCRIPTION
Several things:

* Lone sub-protocol, e.g. `"udp"`, would have an error. Fixes that and several similar issues.
* Basic composite, e.g. `"udp and port 25"` or `"host 10.100.100.100 or port 16"`

The composite remains inefficient, especially when just one field is different. Further optimizations to follow.