### PR TITLE
Introduce new method SetRawBPFFilter to pcap Handle

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -73,6 +73,10 @@ func (h *Handle) SetBPFFilter(expr string) error {
 	if err != nil {
 		return fmt.Errorf("bpf assembly failed: %v", err)
 	}
+	return h.SetRawBPFFilter(raw)
+}
+
+func (h *Handle) SetRawBPFFilter(raw []bpf.RawInstruction) error {
 	h.filter = raw
 	return h.setFilter()
 }


### PR DESCRIPTION
Signed-off-by: Gopi krishna Kodali <gkodali@zededa.com>

This new methods allows for setting pre-computed raw BPF instructions on PCAP handle.