### PR TITLE
darwin: bpf_program bf_len is uint32 not uint16

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -26,11 +26,6 @@ type Packet struct {
 	Error error
 }
 
-type BpfProgram struct {
-	Len    uint32
-	Filter *bpf.RawInstruction
-}
-
 // OpenLive open a live capture. Returns a Handle that implements https://godoc.org/github.com/gopacket/gopacket#PacketDataSource
 // so you can pass it there.
 func OpenLive(device string, snaplen int32, promiscuous bool, timeout time.Duration, syscalls bool) (handle *Handle, _ error) {

--- a/pcap.go
+++ b/pcap.go
@@ -27,7 +27,7 @@ type Packet struct {
 }
 
 type BpfProgram struct {
-	Len    uint16
+	Len    uint32
 	Filter *bpf.RawInstruction
 }
 

--- a/pcap_darwin.go
+++ b/pcap_darwin.go
@@ -83,7 +83,7 @@ func (h *Handle) setFilter() error {
 	 * Try to install the kernel filter.
 	 */
 	prog := BpfProgram{
-		Len:    uint16(len(h.filter)),
+		Len:    uint32(len(h.filter)),
 		Filter: (*bpf.RawInstruction)(unsafe.Pointer(&h.filter[0])),
 	}
 	if err := ioctlPtr(h.fd, syscall.BIOCSETF, unsafe.Pointer(&prog)); err != nil {

--- a/pcap_darwin.go
+++ b/pcap_darwin.go
@@ -32,6 +32,11 @@ type Handle struct {
 	filter      []bpf.RawInstruction
 }
 
+type BpfProgram struct {
+	Len    uint32
+	Filter *bpf.RawInstruction
+}
+
 func (h *Handle) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	if h.syscalls {
 		return h.readPacketDataSyscall()


### PR DESCRIPTION
in MacOS man bpf page

```
struct bpf_program {
    u_int bf_len;
    struct bpf_insn *bf_insns;
};
```

otherwise you will get lots of invalid BPF command for ioctl