### PR TITLE
feat: get link type from ioctl for darwin and bsd system

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -2,5 +2,6 @@ package pcap
 
 // constants, see compliant with pcap-linktype(7) and http://www.tcpdump.org/linktypes.html.
 const (
-	LinkTypeEthernet uint8 = 0x01
+	LinkTypeNull     uint32 = 0x0
+	LinkTypeEthernet uint32 = 0x01
 )

--- a/pcap.go
+++ b/pcap.go
@@ -77,12 +77,6 @@ func (h *Handle) SetRawBPFFilter(raw []bpf.RawInstruction) error {
 	return h.setFilter()
 }
 
-// LinkType return the link type, compliant with pcap-linktype(7) and http://www.tcpdump.org/linktypes.html.
-// For now, we just support Ethernet; some day we may support more
-func (h Handle) LinkType() uint8 {
-	return LinkTypeEthernet
-}
-
 // getEndianness discover the endianness of our current system
 func getEndianness() (binary.ByteOrder, error) {
 	buf := [2]byte{}

--- a/pcap_linux.go
+++ b/pcap_linux.go
@@ -566,3 +566,9 @@ func parseSocketAddrLinkLayer(b []byte, endian binary.ByteOrder) (*syscall.RawSo
 	}
 	return &sall, nil
 }
+
+// LinkType return the link type, compliant with pcap-linktype(7) and http://www.tcpdump.org/linktypes.html.
+// For now, we just support Ethernet; some day we may support more
+func (h Handle) LinkType() uint32 {
+	return LinkTypeEthernet
+}


### PR DESCRIPTION
add FreeBSD and Darwin to check the link type.
Currently, I only tested with PPPoE interface in FreeBSD, and get correct LINKTYPE_NULL.
We can use this to determine what kind of raw BPF should be apply.

And please note, Link Type is more than 1 byte, and refer to BPF man page in FreeBSD, its return type is `u_int` which is `uint32`.


```
 BIOCGDLT	       (u_int) Returns the type	of the data link layer	under-
		       lying the attached interface.  EINVAL is	returned if no
		       interface  has  been specified.	The device types, pre-
		       fixed with "DLT_", are defined in <net/bpf.h>.
```